### PR TITLE
Modify tltd and panl to take relative steps

### DIFF
--- a/libraries/YarpPlugins/LaserTowerOfDeathController/LaserTowerOfDeathController.cpp
+++ b/libraries/YarpPlugins/LaserTowerOfDeathController/LaserTowerOfDeathController.cpp
@@ -32,18 +32,26 @@ bool LaserTowerOfDeathController::stopMovement()
 
 bool LaserTowerOfDeathController::tiltDown(double value)
 {
-    CD_INFO("\n");
-    if (  tiltJointValue > tiltRangeMin )
-        tiltJointValue-=tiltStep;
+    CD_INFO("%f\n", value);
+    if ( tiltJointValue - value > tiltRangeMax )
+        tiltJointValue = tiltRangeMax;
+    else if ( tiltJointValue - value < tiltRangeMin )
+        tiltJointValue = tiltRangeMin;
+    else
+        tiltJointValue -= value;
 
     return sendCurrentJointValues();
 }
 
 bool LaserTowerOfDeathController::panLeft(double value)
 {
-    CD_INFO("\n");
-    if (panJointValue < panRangeMax)
-        panJointValue+=panStep;
+    CD_INFO("%f\n", value);
+    if ( panJointValue + value > panRangeMax )
+        panJointValue = panRangeMax;
+    else if ( panJointValue + value < panRangeMin )
+        panJointValue = panRangeMin;
+    else
+        panJointValue += value;
 
     return sendCurrentJointValues();
 }

--- a/libraries/YarpPlugins/LaserTowerOfDeathController/LaserTowerOfDeathController.hpp
+++ b/libraries/YarpPlugins/LaserTowerOfDeathController/LaserTowerOfDeathController.hpp
@@ -81,12 +81,10 @@ private:
 
     static const int panRangeMin = 0;
     static const int panRangeMax = 180;
-    static const int panStep = 10;
     static const int panInitial = 90;
 
     static const int tiltRangeMin = 0;
     static const int tiltRangeMax = 180;
-    static const int tiltStep = 10;
     static const int tiltInitial = 90;
 
 };


### PR DESCRIPTION
Fixes #19.

* Fixes regression from https://github.com/asrob-uc3m/yarp-devices/commit/ad83d1b6921ace19728688bbc26c63ab8b3c5fff (faulty implementation of `panLeft` and `tiltDown`, movement direction was not taken into account).
* Now this implementation consumes the `value` parameter and overrides the default steps.  